### PR TITLE
Display message when no package.json was found

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ if (!args._.length) {
 }
 
 if (!fs.existsSync(defaults.package)) {
-  return console.log("There is no package.json in ", __dirname);
+  return console.log("No package.json file found. Use `npm init` to create a new package.json file");
 }
 
 // Get


### PR DESCRIPTION
This is for #3

When there is no `package.json` in the current working directory, `npe` will now show an error message instead of throwing an error.

Let me know if you aren’t happy with the wording and I’ll update this pull request.
