### PR TITLE
Fixed package.json existence checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,15 +13,16 @@ var defaults = {
 
 args = merge(defaults, args);
 
-var pkg = require(args.package);
-
 // Usage
 if (!args._.length) {
   return console.log(fs.readFileSync(__dirname + "/example.sh").toString());
 }
 
+// Check package.json existence
 if (!fs.existsSync(defaults.package)) {
   return console.log("No package.json file found. Use `npm init` to create a new package.json file");
+}else{
+  var pkg = require(args.package);
 }
 
 // Get


### PR DESCRIPTION
I found that if you ran `npe` for a path that didn't have a package.json, it threw an error and crashed.  

**e.g. in a location with no package.json:**

```
/tmp/npe$ npe

module.js:472
    throw err;
    ^

Error: Cannot find module '/private/tmp/npe/package.json'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/usr/local/lib/node_modules/npe/index.js:16:11)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
```

After the minor change: 

```
/tmp/npe$ npe

cd some/node/package

# Get values from package.json
npe name
npe scripts
npe scripts.test
npe repository.url
open $(npe repository.url)
...
```

Hope this helps...

Adrian